### PR TITLE
Decrement on exit

### DIFF
--- a/lib/regulator.ex
+++ b/lib/regulator.ex
@@ -7,6 +7,7 @@ defmodule Regulator do
   alias Regulator.Limits
   alias Regulator.Buffer
   alias Regulator.Telemetry
+  alias Regulator.Monitor
 
   @doc """
   Creates a new regulator.
@@ -17,6 +18,23 @@ defmodule Regulator do
   end
 
   @doc """
+  Removes a regulator.
+  """
+  def uninstall(name) do
+    # Find the limit supervisor and terminate it. This will also clean up the
+    # ets tables that we've created since they are created by the supervisor
+    # process. If the process is not found then we assume its already been
+    # killed.
+    case Process.whereis(name) do
+      nil ->
+        :ok
+
+      pid ->
+        DynamicSupervisor.terminate_child(Regulators, pid)
+    end
+  end
+
+  @doc """
   Ask for access to a protected service. If we've reached the concurrency limit
   then `ask` will return a `:dropped` atom without executing the callback. Otherwise
   the callback will be applied. The callback must return tuple with the result
@@ -24,47 +42,83 @@ defmodule Regulator do
   result atoms are:
 
   * `:ok` - The call succeeded.
-  * `:drop` - The call failed or timed out. This is used as a signal to backoff or otherwise adjust the limit.
+  * `:error` - The call failed or timed out. This is used as a signal to backoff or otherwise adjust the limit.
   * `:ignore` - The call should not be counted in the concurrency limit. This is typically used to filter out status checks and other low latency RPCs.
   """
   def ask(name, f) do
+    with {:ok, ctx} <- ask(name) do
+      case safe_execute(ctx, f) do
+        {:ok, result} ->
+          ok(ctx)
+          result
+
+        {:error, result} ->
+          error(ctx)
+          result
+
+        {:ignore, result} ->
+          ignore(ctx)
+          result
+      end
+    end
+  end
+
+  def ask(name) do
+    :ok = Monitor.monitor_me(name)
     inflight = Limits.add(name)
     start = Telemetry.start(:ask, %{regulator: name}, %{inflight: inflight})
 
-    try do
-      if inflight <= Limits.limit(name) do
-        {result, user_result} = f.()
-        rtt                   = System.monotonic_time() - start
-        Limits.sub(name)
-
-        case result do
-          :ok ->
-            Telemetry.stop(:ask, start, %{regulator: name, result: :ok})
-            Buffer.add_sample(name, {rtt, inflight, false})
-            user_result
-
-          :drop ->
-            Telemetry.stop(:ask, start, %{regulator: name, result: :drop})
-            Buffer.add_sample(name, {rtt, inflight, true})
-            user_result
-
-          :ignore ->
-            Telemetry.stop(:ask, start, %{regulator: name, result: :ignore})
-            user_result
-        end
-      else
-        Telemetry.stop(:ask, start, %{regulator: name, result: :dropped})
-        Limits.sub(name)
-        :dropped
-      end
-    rescue
-      error ->
-        Telemetry.exception(:ask, start, :error, error, __STACKTRACE__, %{regulator: name})
-        reraise error, __STACKTRACE__
-    catch
-      :exit, reason ->
-        Telemetry.exception(:ask, start, :exit, reason, __STACKTRACE__, %{regulator: name})
-        exit(reason)
+    if inflight <= Limits.limit(name) do
+      {:ok, %{start: start, name: name, inflight: inflight}}
+    else
+      Limits.sub(name)
+      Monitor.demonitor_me(name)
+      Telemetry.stop(:ask, start, %{regulator: name, result: :dropped})
+      :dropped
     end
+  end
+
+  def ok(ctx) do
+    rtt = System.monotonic_time() - ctx.start
+    Telemetry.stop(:ask, ctx.start, %{regulator: ctx.name, result: :ok})
+    Buffer.add_sample(ctx.name, {rtt, ctx.inflight, false})
+    Limits.sub(ctx.name)
+    Monitor.demonitor_me(ctx.name)
+
+    :ok
+  end
+
+  def error(ctx) do
+    rtt = System.monotonic_time() - ctx.start
+    Telemetry.stop(:ask, ctx.start, %{regulator: ctx.name, result: :drop})
+    Buffer.add_sample(ctx.name, {rtt, ctx.inflight, true})
+    Limits.sub(ctx.name)
+    Monitor.demonitor_me(ctx.name)
+
+    :ok
+  end
+
+  def ignore(ctx) do
+    Telemetry.stop(:ask, ctx.start, %{regulator: ctx.name, result: :ignore})
+    Limits.sub(ctx.name)
+    Monitor.demonitor_me(ctx.name)
+
+    :ok
+  end
+
+  defp safe_execute(ctx, f) do
+    f.()
+  rescue
+    error ->
+      Limits.sub(ctx.name)
+      Monitor.demonitor_me(ctx.name)
+      Telemetry.exception(:ask, ctx.start, :error, error, __STACKTRACE__, %{regulator: ctx.name})
+      reraise error, __STACKTRACE__
+  catch
+    kind, reason ->
+      Limits.sub(ctx.name)
+      Monitor.demonitor_me(ctx.name)
+      Telemetry.exception(:ask, ctx.start, kind, reason, __STACKTRACE__, %{regulator: ctx.name})
+      :erlang.raise(kind, reason, __STACKTRACE__)
   end
 end

--- a/lib/regulator/limit/gradient.ex
+++ b/lib/regulator/limit/gradient.ex
@@ -34,25 +34,30 @@ defmodule Regulator.Limit.Gradient do
   def update(gradient, _current_limit, window) do
     queue_size = 4 # This should be determined dynamically
 
-    short_rtt  = Window.avg_rtt(window)
-    long_rtt   = update_long_rtt(gradient.long_rtt, short_rtt)
-    gradient   = %{gradient | long_rtt: long_rtt}
+    case Window.avg_rtt(window) do
+      0 ->
+        {gradient, gradient.estimated_limit}
 
-    # If we don't have enough inflight requests we don't really need to grow the limit
-    # So just bail out.
-    if window.max_inflight < gradient.estimated_limit / 2 do
-      {gradient, gradient.estimated_limit}
-    else
-      grad = max(0.5, min(1.0, gradient.rtt_tolerance * long_rtt.value / short_rtt))
-      new_limit = gradient.estimated_limit * grad + queue_size
-      # Calculate the EMA of the estimated limit
-      new_limit = gradient.estimated_limit * (1 - gradient.smoothing) + new_limit * gradient.smoothing
+      short_rtt ->
+        long_rtt   = update_long_rtt(gradient.long_rtt, short_rtt)
+        gradient   = %{gradient | long_rtt: long_rtt}
 
-      # Clamp the limit values based on the users configuration
-      new_limit = max(gradient.min_limit, min(gradient.max_limit, new_limit))
-      gradient = %{gradient | estimated_limit: new_limit}
+        # If we don't have enough inflight requests we don't really need to grow the limit
+        # So just bail out.
+        if window.max_inflight < gradient.estimated_limit / 2 do
+          {gradient, gradient.estimated_limit}
+        else
+          grad = max(0.5, min(1.0, gradient.rtt_tolerance * long_rtt.value / short_rtt))
+          new_limit = gradient.estimated_limit * grad + queue_size
+          # Calculate the EMA of the estimated limit
+          new_limit = gradient.estimated_limit * (1 - gradient.smoothing) + new_limit * gradient.smoothing
 
-      {gradient, trunc(new_limit)}
+          # Clamp the limit values based on the users configuration
+          new_limit = max(gradient.min_limit, min(gradient.max_limit, new_limit))
+          gradient = %{gradient | estimated_limit: new_limit}
+
+          {gradient, trunc(new_limit)}
+        end
     end
   end
 

--- a/lib/regulator/limit_calculator.ex
+++ b/lib/regulator/limit_calculator.ex
@@ -34,10 +34,6 @@ defmodule Regulator.LimitCalculator do
     {mod, opts} = state.limit
     {opts, new_limit} = mod.update(opts, current_limit, window)
 
-    if current_limit != new_limit do
-      Logger.debug("New limit: #{new_limit}")
-    end
-
     Limits.set_limit(state.limits, new_limit)
     Telemetry.event(:limit, %{limit: new_limit}, %{regulator: state.name})
     state = %{state | limit: {mod, opts}}

--- a/lib/regulator/limiter_sup.ex
+++ b/lib/regulator/limiter_sup.ex
@@ -3,7 +3,7 @@ defmodule Regulator.LimiterSup do
   use Supervisor
 
   def start_link(opts) do
-    Supervisor.start_link(__MODULE__, opts)
+    Supervisor.start_link(__MODULE__, opts, name: opts[:name])
   end
 
   def init(opts) do
@@ -22,7 +22,8 @@ defmodule Regulator.LimiterSup do
     }
 
     children = [
-      {Regulator.LimitCalculator, calculator_config}
+      {Regulator.Monitor, name: name},
+      {Regulator.LimitCalculator, calculator_config},
     ]
 
     Supervisor.init(children, strategy: :one_for_one)

--- a/lib/regulator/limits.ex
+++ b/lib/regulator/limits.ex
@@ -20,6 +20,11 @@ defmodule Regulator.Limits do
     :ets.update_counter(:"#{name}-limits", :inflight, {2, -1, 0, 0}, {:inflight, 0})
   end
 
+  def inflight(name) do
+    [{:inflight, count}] = :ets.lookup(:"#{name}-limits", :inflight)
+    count
+  end
+
   # Get the current concurrency limit
   def limit(name) do
     [{:max_inflight, limit}] = :ets.lookup(:"#{name}-limits", :max_inflight)

--- a/lib/regulator/monitor.ex
+++ b/lib/regulator/monitor.ex
@@ -1,0 +1,47 @@
+defmodule Regulator.Monitor do
+  @moduledoc false
+  use GenServer
+
+  alias Regulator.Limits
+
+  def start_link(opts) do
+    # TODO - make this not suck later
+    name = opts[:name]
+    GenServer.start_link(__MODULE__, opts, name: :"#{name}-monitor")
+  end
+
+  def monitor_me(name) do
+    GenServer.call(:"#{name}-monitor", :monitor)
+  end
+
+  def demonitor_me(name) do
+    GenServer.call(:"#{name}-monitor", :monitor)
+  end
+
+  def init(opts) do
+    data = %{
+      name: opts[:name],
+      refs: %{},
+    }
+    {:ok, data}
+  end
+
+  def handle_call(:monitor, {pid, _}, state) do
+    ref = Process.monitor(pid)
+    state = put_in(state, [:refs, pid], ref)
+    {:reply, :ok, state}
+  end
+
+  def handle_call(:demonitor, {pid, _}, state) do
+    {ref, refs} = Map.pop(state.refs, pid)
+    Process.demonitor(ref)
+
+    {:reply, :ok, %{state | refs: refs}}
+  end
+
+  def handle_info({:DOWN, _ref, :process, pid, _reason}, state) do
+    refs = Map.delete(state.refs, pid)
+    Limits.sub(state.name)
+    {:noreply, %{state | refs: refs}}
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -32,7 +32,8 @@ defmodule Regulator.MixProject do
       {:telemetry, "~> 0.4"},
 
       {:credo, "~> 1.4", only: [:dev, :test], runtime: false},
-      {:ex_doc, "~> 0.19", only: [:dev, :test]}
+      {:ex_doc, "~> 0.19", only: [:dev, :test]},
+      {:propcheck, "~> 1.2", only: [:dev, :test]},
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -7,5 +7,7 @@
   "makeup": {:hex, :makeup, "1.0.1", "82f332e461dc6c79dbd82fbe2a9c10d48ed07146f0a478286e590c83c52010b5", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "49736fe5b66a08d8575bf5321d716bac5da20c8e6b97714fec2bcd6febcfa1f8"},
   "makeup_elixir": {:hex, :makeup_elixir, "0.14.0", "cf8b7c66ad1cff4c14679698d532f0b5d45a3968ffbcbfd590339cb57742f1ae", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "d4b316c7222a85bbaa2fd7c6e90e37e953257ad196dc229505137c5e505e9eff"},
   "nimble_parsec": {:hex, :nimble_parsec, "0.5.3", "def21c10a9ed70ce22754fdeea0810dafd53c2db3219a0cd54cf5526377af1c6", [:mix], [], "hexpm", "589b5af56f4afca65217a1f3eb3fee7e79b09c40c742fddc1c312b3ac0b3399f"},
+  "propcheck": {:hex, :propcheck, "1.2.0", "e2b84f2f1a4c46b6b2aa22a0f6ddf97696f99d4a5c8f71d45f6519741e727eca", [:mix], [{:proper, "~> 1.3", [hex: :proper, repo: "hexpm", optional: false]}], "hexpm", "0f4fb2393fa5321ba7f23a8feabc861ac825e62d9e1db4aa35e39cace4c5c08d"},
+  "proper": {:hex, :proper, "1.3.0", "c1acd51c51da17a2fe91d7a6fc6a0c25a6a9849d8dc77093533109d1218d8457", [:make, :mix, :rebar3], [], "hexpm", "4aa192fccddd03fdbe50fef620be9d4d2f92635b54f55fb83aec185994403cbc"},
   "telemetry": {:hex, :telemetry, "0.4.1", "ae2718484892448a24470e6aa341bc847c3277bfb8d4e9289f7474d752c09c7f", [:rebar3], [], "hexpm", "4738382e36a0a9a2b6e25d67c960e40e1a2c95560b9f936d8e29de8cd858480f"},
 }

--- a/test/regulator/limit/aimd_test.exs
+++ b/test/regulator/limit/aimd_test.exs
@@ -1,9 +1,0 @@
-defmodule Regulator.Limit.AIMDTest do
-  use ExUnit.Case, async: true
-
-  alias Regulator.Limit.AIMD
-
-  test "can create an aimd limit" do
-    _limit = %AIMD{}
-  end
-end

--- a/test/regulator_test.exs
+++ b/test/regulator_test.exs
@@ -1,14 +1,23 @@
 defmodule RegulatorTest do
   use ExUnit.Case
-
   alias Regulator.Limit.Static
 
-  test "can create a new regulator" do
-    Regulator.install(:static_limit, {Static, limit: 2})
+  @reg :static_limit
 
-    result = Regulator.ask(:static_limit, fn ->
-      result = Regulator.ask(:static_limit, fn ->
-        assert :dropped = Regulator.ask(:static_limit, fn -> nil end)
+  setup do
+    Regulator.install(@reg, {Static, limit: 2})
+
+    on_exit fn ->
+      Regulator.uninstall(@reg)
+    end
+
+    :ok
+  end
+
+  test "can install and uninstall regulators" do
+    result = Regulator.ask(@reg, fn ->
+      result = Regulator.ask(@reg, fn ->
+        assert :dropped = Regulator.ask(@reg, fn -> nil end)
         {:ok, :dropped}
       end)
 
@@ -16,5 +25,55 @@ defmodule RegulatorTest do
     end)
 
     assert result == :dropped
+    assert Regulator.uninstall(@reg) == :ok
+  end
+
+  test "crashing processes are cleaned up" do
+    Process.flag(:trap_exit, true)
+
+    spawn_link(fn ->
+      {:ok, _ctx} = Regulator.ask(@reg)
+      throw :exit
+    end)
+
+    assert_receive {:EXIT, _, _}
+    eventually(fn ->
+      assert Regulator.Limits.inflight(@reg) == 0
+    end)
+  end
+
+  test "callbacks that raise exceptions are re-thrown" do
+    assert_raise ArgumentError, fn ->
+      Regulator.ask(@reg, fn -> raise ArgumentError, "bang" end)
+    end
+
+    assert Regulator.Limits.inflight(@reg) == 0
+  end
+
+  test "callbacks that throw are re-thrown" do
+    assert catch_throw(Regulator.ask(@reg, fn -> throw :exit end))
+
+    assert Regulator.Limits.inflight(@reg) == 0
+  end
+
+  defp eventually(f, retries \\ 0) do
+    if retries > 10 do
+      false
+    else
+      if f.() do
+        true
+      else
+        :timer.sleep(100)
+        eventually(f, retries + 1)
+      end
+    end
+  rescue
+    err ->
+      if retries == 10 do
+        reraise err, __STACKTRACE__
+      else
+        :timer.sleep(200)
+        eventually(f, retries + 1)
+      end
   end
 end


### PR DESCRIPTION
This PR fixes several bugs and ensures that counts are decremented if the inflight process crashes before returning a result. I've also re-added the explicit API for marking a call as a success or failure. This is a less elegant API and it requires the user to handle more errors but its needed to support things like Plug.