### PR TITLE
Fixes a bug with inflight telemetry metadata

### DIFF
--- a/lib/regulator.ex
+++ b/lib/regulator.ex
@@ -83,9 +83,10 @@ defmodule Regulator do
   def ask(name) do
     :ok = Monitor.monitor_me(name)
     inflight = Limits.add(name)
-    start = Telemetry.start(:ask, %{regulator: name}, %{inflight: inflight})
+    limit = Limits.limit(name)
+    start = Telemetry.start(:ask, %{regulator: name}, %{inflight: min(inflight, limit)})
 
-    if inflight <= Limits.limit(name) do
+    if inflight <= limit do
       {:ok, %{start: start, name: name, inflight: inflight}}
     else
       Limits.sub(name)


### PR DESCRIPTION
The `inflight` telemetry metadata on `[:regulator, :ask, :start]` uses the concurrent request counter, but without adjusting for the limit. This means that in a scenario where you have a limit of 1 and you call `Regulator.ask`, the value will be 2 (the current ongoing request + the increment of the counter). The call will be `:dropped` and the counter decremented, but the telemetry metadata for the call reports inflight 2. This change ensures that the reported value is the value of the counter or, if the limit is exceeded, the limit, accurately representing the number of inflight requests.