### PR TITLE
The Telemetry module docs mentions :drop but not :error

### DIFF
--- a/lib/regulator/telemetry.ex
+++ b/lib/regulator/telemetry.ex
@@ -28,7 +28,7 @@ defmodule Regulator.Telemetry do
 
     #### Metadata
       * `:regulator` - The name of the regulator
-      * `:result` - The result of the call, either `:ok`, `:dropped`, `:drop`, or `:ignore`
+      * `:result` - The result of the call, either `:ok`, `:dropped`, `:error`, or `:ignore`
 
   * `[:regulator, :ask, :exception]` - Called if the callback passed to `ask` raises or throws
 


### PR DESCRIPTION
As far as I can tell, the `stop` event result metadata will never have the value `:drop` (although it does `:dropped`) and the module doc is missing `:error` as a possible value.